### PR TITLE
Fixing non-assignment of defaultPort in ConfigUtils HostAndPort function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 dependency-reduced-pom.xml
+.idea
+*.iml

--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/ConfigUtils.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/config/ConfigUtils.java
@@ -165,10 +165,10 @@ public class ConfigUtils {
   }
 
   static HostAndPort hostAndPort(String input, Integer defaultPort) {
-    final HostAndPort result = HostAndPort.fromString(input);
+    HostAndPort result = HostAndPort.fromString(input);
 
     if (null != defaultPort) {
-      result.withDefaultPort(defaultPort);
+      result = result.withDefaultPort(defaultPort);
     }
 
     return result;

--- a/connect-utils/src/test/java/com/github/jcustenborder/kafka/connect/utils/config/ConfigUtilsTest.java
+++ b/connect-utils/src/test/java/com/github/jcustenborder/kafka/connect/utils/config/ConfigUtilsTest.java
@@ -18,6 +18,7 @@ package com.github.jcustenborder.kafka.connect.utils.config;
 import com.github.jcustenborder.kafka.connect.utils.config.ConfigUtilsTestConfig.EnumTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,7 +35,13 @@ public class ConfigUtilsTest {
     );
     List<EnumTest> actual = ConfigUtils.getEnums(EnumTest.class, config, ConfigUtilsTestConfig.ENUMS_VALUE_CONF);
     assertEquals(ImmutableList.of(EnumTest.ONE), actual);
+  }
 
+  @Test
+  public void testDefaultPortHostConfig() {
+    HostAndPort hostAndPort = ConfigUtils.hostAndPort("123.4.2.3", 6432);
+    HostAndPort intended = HostAndPort.fromString("123.4.2.3:6432");
+    assertEquals(hostAndPort, intended);
   }
 
 }


### PR DESCRIPTION
I came across this error while analyzing code and writing test cases for `kafka-connect-redis`.

`com.google.common.net.HostAndPort.withDefaultPort()` does not modify the HostAndPort object called upon, but instead returns a new instance in case the port is not assigned (-1).

As a result, in `ConfigUtils.hostAndPort(String, Integer)` function, which calls the above `withDefaultPort()` function, result has to be overwritten in cases where defaultPort is not null. Prior to this fix, defaultPort function call succeeded, but didn't reflect in the return value from the `ConfigUtils.hostAndPort(String, Integer)` function.

Also wrote a simple test case for the fix. 