### PR TITLE
Fix early timeout

### DIFF
--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
@@ -128,7 +128,7 @@ class SourceRecordDequeImpl extends ConcurrentLinkedDeque<SourceRecord> implemen
     int count = 0;
     SourceRecord record;
     log.trace("drain() - Attempting to draining {} record(s).", this.batchSize);
-    while (count <= this.batchSize && null != (record = this.poll())) {
+    while (count < this.batchSize && null != (record = this.poll())) {
       result.add(record);
       count++;
     }
@@ -159,7 +159,7 @@ class SourceRecordDequeImpl extends ConcurrentLinkedDeque<SourceRecord> implemen
     int count = 0;
     SourceRecord record;
     log.trace("drain() - Attempting to draining {} record(s).", this.batchSize);
-    while (count <= this.batchSize && null != (record = this.poll())) {
+    while (count < this.batchSize && null != (record = this.poll())) {
       records.add(record);
       count++;
     }

--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
@@ -63,9 +63,9 @@ class SourceRecordDequeImpl extends ConcurrentLinkedDeque<SourceRecord> implemen
     }
     if (size() >= this.maximumCapacity) {
       final long start = this.time.milliseconds();
-      long elapsed = start;
       while (size() >= this.maximumCapacity) {
-        if (elapsed > this.maximumCapacityTimeoutMs) {
+        final long elapsedMs = this.time.milliseconds() - start;
+        if (elapsedMs > this.maximumCapacityTimeoutMs) {
           throw new TimeoutException(
               String.format(
                   "Timeout of %s ms exceeded while waiting for Deque to be drained below %s",
@@ -75,7 +75,6 @@ class SourceRecordDequeImpl extends ConcurrentLinkedDeque<SourceRecord> implemen
           );
         }
         this.time.sleep(this.maximumCapacityWaitMs);
-        elapsed = (this.time.milliseconds() - start);
       }
     }
   }


### PR DESCRIPTION
I believe the current implementation of SourceRecordDequeImpl#waitForCapacity throws TimeoutExceptions too early due to the way the elapsed time is calculate.

Moreover, there seem to be 2 off-by-one errors which will cause the the underlying arrays of the ArrayList to be resized.