### PR TITLE
MINOR: Fix the incorrect initialization of elapsed time from start time to 0. The subsequent timeout condition would fire immediately.

### DIFF
--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeImpl.java
@@ -63,7 +63,7 @@ class SourceRecordDequeImpl extends ConcurrentLinkedDeque<SourceRecord> implemen
     }
     if (size() >= this.maximumCapacity) {
       final long start = this.time.milliseconds();
-      long elapsed = start;
+      long elapsed = 0;
       while (size() >= this.maximumCapacity) {
         if (elapsed > this.maximumCapacityTimeoutMs) {
           throw new TimeoutException(


### PR DESCRIPTION
Initializing the timeout to start time would always be greater than the max timeout triggering the timeout condition immediately. This PR fixes it to start from 0ms.