### PR TITLE
[#212] Support kafka 3.7.1

### DIFF
--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/transformation/BaseKeyValueTransformation.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/transformation/BaseKeyValueTransformation.java
@@ -37,12 +37,11 @@ import java.util.Map;
  * @param <R>
  */
 public abstract class BaseKeyValueTransformation<R extends ConnectRecord<R>> implements Transformation<R> {
-  protected final boolean isKey;
   private static final Logger log = LoggerFactory.getLogger(BaseKeyValueTransformation.class);
 
-  protected BaseKeyValueTransformation(boolean isKey) {
-    this.isKey = isKey;
-  }
+  protected BaseKeyValueTransformation() {}
+
+  protected boolean isKey;
 
   protected SchemaAndValue processMap(R record, Map<String, Object> input) {
     throw new UnsupportedOperationException("MAP is not a supported type.");

--- a/connect-utils/src/test/java/com/github/jcustenborder/kafka/connect/utils/transformation/BaseKeyValueTransformationTest.java
+++ b/connect-utils/src/test/java/com/github/jcustenborder/kafka/connect/utils/transformation/BaseKeyValueTransformationTest.java
@@ -12,8 +12,8 @@ import java.util.Map;
 public class BaseKeyValueTransformationTest {
   static class Base<R extends ConnectRecord<R>> extends BaseKeyValueTransformation<R> {
 
-    protected Base(boolean isKey) {
-      super(isKey);
+    protected Base() {
+      super();
     }
 
     @Override
@@ -33,8 +33,10 @@ public class BaseKeyValueTransformationTest {
   }
   static class StringTransformation<R extends ConnectRecord<R>> extends Base<R> {
     public StringTransformation() {
-      super(true);
+      super();
     }
+
+    protected boolean isKey = true;
 
     @Override
     protected SchemaAndValue processString(R record, Schema inputSchema, String input) {

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <url>https://github.com/jcustenborder/connect-utils/issues</url>
     </issueManagement>
     <properties>
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>3.7.1</kafka.version>
         <guava.version>31.1-jre</guava.version>
         <freemarker.version>2.3.31</freemarker.version>
         <jackson.version>2.12.6.20220326</jackson.version>
@@ -237,6 +237,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
This is a base PR to make https://github.com/jcustenborder/kafka-connect-transform-common compatible with newest kafka version (3.7.1). Newer kafka(-connect) versions need a default constructor for kafka-connect plugins which this PR addresses. See #212 

Beside this it fixes a problem with failing tests when not running in UTC timezone.