### PR TITLE
[#212] support kafka 3.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <url>https://github.com/jcustenborder/connect-utils/issues</url>
     </issueManagement>
     <properties>
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>3.7.1</kafka.version>
         <guava.version>31.1-jre</guava.version>
         <freemarker.version>2.3.31</freemarker.version>
         <jackson.version>2.12.6.20220326</jackson.version>


### PR DESCRIPTION
This  fixes #212 and is a base PR to make https://github.com/jcustenborder/kafka-connect-transform-common compatible with newest kafka version (3.7.1). See follow-up PR https://github.com/jcustenborder/kafka-connect-transform-common/pull/113

Beside this it fixes a problem with failing tests when not running in UTC timezone.