### PR TITLE
Upgrade Kafka build and release workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,115 @@
+name: Maven
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Verify
+        run: mvn -B clean verify
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java and Maven Central credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: oss.sonatype.org
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Compute release version
+        id: release_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          snapshot_version="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          if [[ ! "${snapshot_version}" =~ ^[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+            echo "Root project version must be major.minor-SNAPSHOT. Found: ${snapshot_version}" >&2
+            exit 1
+          fi
+
+          base_version="${snapshot_version%-SNAPSHOT}"
+          git fetch --tags --force
+
+          latest_patch="$(
+            git tag --list "${base_version}.*" |
+              awk -v base="${base_version}" '
+                index($0, base ".") == 1 {
+                  patch = substr($0, length(base) + 2)
+                  if (patch ~ /^[0-9]+$/) print patch
+                }
+              ' |
+              sort -n |
+              tail -1
+          )"
+
+          if [[ -z "${latest_patch}" ]]; then
+            next_patch=0
+          else
+            next_patch=$((latest_patch + 1))
+          fi
+
+          release_version="${base_version}.${next_patch}"
+          if git rev-parse -q --verify "refs/tags/${release_version}" >/dev/null; then
+            echo "Release tag ${release_version} already exists." >&2
+            exit 1
+          fi
+
+          echo "version=${release_version}" >> "${GITHUB_OUTPUT}"
+          echo "Computed release version: ${release_version}"
+
+      - name: Set Maven release version
+        run: mvn -B versions:set -DgenerateBackupPoms=false -DnewVersion="${{ steps.release_version.outputs.version }}"
+
+      - name: Deploy to Maven Central
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
+        run: mvn -B -Pmaven-central -Dgpg.keyname="${GPG_KEYNAME}" clean deploy
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.release_version.outputs.version }}" \
+            --target "${GITHUB_SHA}" \
+            --title "${{ steps.release_version.outputs.version }}" \
+            --generate-notes

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,0 @@
-#!groovy
-@Library('jenkins-pipeline') import com.github.jcustenborder.jenkins.pipeline.MavenCentralPipeline
-
-def pipe = new MavenCentralPipeline()
-pipe.javaVersion = 8
-pipe.execute()

--- a/connect-utils-jackson/pom.xml
+++ b/connect-utils-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>connect-utils-parent</artifactId>
-        <version>0.7-SNAPSHOT</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
     <artifactId>connect-utils-jackson</artifactId>
     <name>connect-utils-jackson</name>

--- a/connect-utils-parser/pom.xml
+++ b/connect-utils-parser/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>connect-utils-parent</artifactId>
-        <version>0.7-SNAPSHOT</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
     <artifactId>connect-utils-parser</artifactId>
     <name>connect-utils-parser</name>

--- a/connect-utils-testing-data/pom.xml
+++ b/connect-utils-testing-data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>connect-utils-parent</artifactId>
-        <version>0.7-SNAPSHOT</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
     <artifactId>connect-utils-testing-data</artifactId>
     <name>connect-utils-testing-data</name>

--- a/connect-utils-testing/pom.xml
+++ b/connect-utils-testing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>connect-utils-parent</artifactId>
-        <version>0.7-SNAPSHOT</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
     <artifactId>connect-utils-testing</artifactId>
     <name>connect-utils-testing</name>

--- a/connect-utils/pom.xml
+++ b/connect-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>connect-utils-parent</artifactId>
-        <version>0.7-SNAPSHOT</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
     <artifactId>connect-utils</artifactId>
     <name>connect-utils</name>

--- a/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeBuilder.java
+++ b/connect-utils/src/main/java/com/github/jcustenborder/kafka/connect/utils/data/SourceRecordDequeBuilder.java
@@ -17,7 +17,6 @@ package com.github.jcustenborder.kafka.connect.utils.data;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
-import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 public class SourceRecordDequeBuilder {
@@ -25,7 +24,7 @@ public class SourceRecordDequeBuilder {
 
   }
 
-  Time time = SystemTime.SYSTEM;
+  Time time = Time.SYSTEM;
   private int maximumCapacity = Integer.MAX_VALUE;
   private int batchSize = 1024;
   private int emptyWaitMs = 0;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jcustenborder.kafka.connect</groupId>
     <artifactId>connect-utils-parent</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>connect-utils-parent</name>
     <description>A helper library for building Kafka Connect Connectors.</description>
@@ -65,10 +65,10 @@
         <url>https://github.com/jcustenborder/connect-utils/issues</url>
     </issueManagement>
     <properties>
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <guava.version>31.1-jre</guava.version>
         <freemarker.version>2.3.31</freemarker.version>
-        <jackson.version>2.12.6.20220326</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <reflections.version>0.9.10</reflections.version>
         <mockito.version>3.9.0</mockito.version>
         <immutables.version>2.8.2</immutables.version>
@@ -265,11 +265,17 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.13.0</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.immutables</groupId>
+                            <artifactId>value</artifactId>
+                            <version>${immutables.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -294,7 +300,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                         </configuration>
                     </execution>
                 </executions>
@@ -318,7 +324,7 @@
                                 </goals>
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
-                                    <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                                    <passphraseServerId>gpg.passphrase</passphraseServerId>
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>


### PR DESCRIPTION
Closes #215\n\n## Summary\n- Upgrade project version to 0.8-SNAPSHOT, Kafka to 4.3.1, Jackson BOM to 2.21.2, and Java baseline to 17.\n- Replace Jenkins with a GitHub Actions Maven verify/release workflow.\n- Use Kafka's public Time.SYSTEM API and explicitly configure Immutables annotation processing for modern JDKs.\n\n## Verification\n- mvn -B clean verify\n- mvn -q -DforceStdout help:evaluate -Dexpression=project.version\n- mvn -q -DforceStdout help:evaluate -Dexpression=kafka.version\n- mvn -q -DforceStdout help:evaluate -Dexpression=jackson.version\n- mvn -B dependency:tree -Dincludes=com.fasterxml.jackson\n- mvn -B -pl connect-utils-jackson -am dependency:tree -Dincludes=com.fasterxml.jackson.core\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/maven.yml"); puts "yaml ok"'\n- release-version script check: no matching tags -> 1.1.0; tags 1.1.0 and 1.1.2 -> 1.1.3\n\n## Notes\n- No tracked Docker extension/Testcontainers references were found, so no Testcontainers dependency was added.\n- GitHub Project status was not changed because this repo AGENTS.md does not define project/status workflow rules.